### PR TITLE
メンションリセットされないのを修正

### DIFF
--- a/tasks/internal/youtube.go
+++ b/tasks/internal/youtube.go
@@ -73,6 +73,7 @@ func run(
 			messages = append(messages, message)
 			userMentions = nil
 			roleMentions = nil
+			mentionsMessage = ""
 		}
 	}
 	if !lastPostedAt.IsZero() {


### PR DESCRIPTION
# なぜやるか
- メンションのリセットがされずにすさまじいことになったため。
![image](https://github.com/user-attachments/assets/5ee285d3-8fe1-4689-8897-59dc1c01b735)

# やったこと
- Webhookに投稿したらメンションをリセットするよう変更。
# 積み残し
- 特になし。
# 確認事項
- [x] 想定通りに動作するか確認したか
- [x] テストコードはすべて通るか
