### PR TITLE
画面共有中に退出すると通知されない不具合を修正

### DIFF
--- a/bot/cogs/on_voice_state_update.go
+++ b/bot/cogs/on_voice_state_update.go
@@ -2,7 +2,6 @@ package cogs
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -145,7 +144,6 @@ func onVoiceStateUpdateFunc(
 			}
 		}
 	}
-	fmt.Println(vs.BeforeUpdate != nil && (!vs.BeforeUpdate.SelfVideo == !vs.SelfVideo) && (!vs.BeforeUpdate.SelfStream == !vs.SelfStream))
 	//chengeVcChannelFlag := (vs.BeforeUpdate != nil) && (vs.ChannelID != "") && (vs.BeforeUpdate.ChannelID != vs.ChannelID)
 	if vs.BeforeUpdate != nil && (!vs.BeforeUpdate.SelfVideo == !vs.SelfVideo) && (!vs.BeforeUpdate.SelfStream == !vs.SelfStream) {
 		vcChannel, err := state.Channel(vs.BeforeUpdate.ChannelID)

--- a/bot/cogs/on_voice_state_update.go
+++ b/bot/cogs/on_voice_state_update.go
@@ -2,6 +2,7 @@ package cogs
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -144,8 +145,9 @@ func onVoiceStateUpdateFunc(
 			}
 		}
 	}
+	fmt.Println(vs.BeforeUpdate != nil && (!vs.BeforeUpdate.SelfVideo == !vs.SelfVideo) && (!vs.BeforeUpdate.SelfStream == !vs.SelfStream))
 	//chengeVcChannelFlag := (vs.BeforeUpdate != nil) && (vs.ChannelID != "") && (vs.BeforeUpdate.ChannelID != vs.ChannelID)
-	if vs.BeforeUpdate != nil && (!vs.BeforeUpdate.SelfVideo == !vs.BeforeUpdate.SelfStream) && (!vs.SelfVideo == !vs.SelfStream) {
+	if vs.BeforeUpdate != nil && (!vs.BeforeUpdate.SelfVideo == !vs.SelfVideo) && (!vs.BeforeUpdate.SelfStream == !vs.SelfStream) {
 		vcChannel, err := state.Channel(vs.BeforeUpdate.ChannelID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# なぜやるか
- 画面共有中に退出すると通知されない不具合があったため修正
# やったこと
- 退出時の条件変更
# 積み残し
- 特になし
# 確認事項
- [x] 想定通りに動作するか確認したか
- [x] テストコードはすべて通るか
