### PR TITLE
Webhookの送信にスレッドを対応させる

### DIFF
--- a/core/schema.sql
+++ b/core/schema.sql
@@ -273,6 +273,13 @@ CREATE TABLE IF NOT EXISTS webhook_word (
     FOREIGN KEY(webhook_serial_id) REFERENCES webhook(webhook_serial_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS webhook_thread (
+    webhook_serial_id INTEGER,
+    thread_id TEXT NOT NULL,
+    PRIMARY KEY(webhook_serial_id, thread_id),
+    FOREIGN KEY(webhook_serial_id) REFERENCES webhook(webhook_serial_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS line_bot (
     guild_id TEXT NOT NULL,
     line_notify_token BYTEA,

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -81,6 +81,9 @@ type RepositoryFuncMock struct {
 	InsertWebhookRoleMentionFunc                          func(ctx context.Context, webhookSerialID int64, roleID string) error
 	GetWebhookRoleMentionWithWebhookSerialIDFunc          func(ctx context.Context, webhookSerialID int64) ([]*WebhookRoleMention, error)
 	DeleteWebhookRoleMentionsNotInProvidedListFunc        func(ctx context.Context, webhookSerialID int64, roleIDs []string) error
+	InsertWebhookThreadFunc                               func(ctx context.Context, webhookSerialID int64, threadID string) error
+	GetWebhookThreadWithWebhookSerialIDFunc               func(ctx context.Context, webhookSerialID int64) ([]*WebhookThread, error)
+	DeleteWebhookThreadsNotInProvidedListFunc             func(ctx context.Context, webhookSerialID int64) error
 }
 
 func (r *RepositoryFuncMock) InsertLineBotIvByGuildID(ctx context.Context, guildId string) error {
@@ -335,6 +338,18 @@ func (r *RepositoryFuncMock) DeleteWebhookRoleMentionsNotInProvidedList(ctx cont
 	return r.DeleteWebhookRoleMentionsNotInProvidedListFunc(ctx, webhookSerialID, roleIDs)
 }
 
+func (r *RepositoryFuncMock) InsertWebhookThread(ctx context.Context, webhookSerialID int64, threadID string) error {
+	return r.InsertWebhookThreadFunc(ctx, webhookSerialID, threadID)
+}
+
+func (r *RepositoryFuncMock) GetWebhookThreadWithWebhookSerialID(ctx context.Context, webhookSerialID int64) ([]*WebhookThread, error) {
+	return r.GetWebhookThreadWithWebhookSerialIDFunc(ctx, webhookSerialID)
+}
+
+func (r *RepositoryFuncMock) DeleteWebhookThreadsNotInProvidedList(ctx context.Context, webhookSerialID int64) error {
+	return r.DeleteWebhookThreadsNotInProvidedListFunc(ctx, webhookSerialID)
+}
+
 // Repository is an interface for repository.
 type RepositoryFunc interface {
 	InsertLineBotIvByGuildID(ctx context.Context, guildId string) error
@@ -400,6 +415,9 @@ type RepositoryFunc interface {
 	InsertWebhookRoleMention(ctx context.Context, webhookSerialID int64, roleID string) error
 	GetWebhookRoleMentionWithWebhookSerialID(ctx context.Context, webhookSerialID int64) ([]*WebhookRoleMention, error)
 	DeleteWebhookRoleMentionsNotInProvidedList(ctx context.Context, webhookSerialID int64, roleIDs []string) error
+	InsertWebhookThread(ctx context.Context, webhookSerialID int64, threadID string) error
+	GetWebhookThreadWithWebhookSerialID(ctx context.Context, webhookSerialID int64) ([]*WebhookThread, error)
+	DeleteWebhookThreadsNotInProvidedList(ctx context.Context, webhookSerialID int64) error
 }
 
 var (

--- a/repository/webhook_thread.go
+++ b/repository/webhook_thread.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"context"
+)
+
+type WebhookThread struct {
+	WebhookSerialID int64  `db:"webhook_serial_id"`
+	ThreadID        string `db:"thread_id"`
+}
+
+func (r *Repository) InsertWebhookThread(
+	ctx context.Context,
+	webhookSerialID int64,
+	threadID string,
+) error {
+	query := `
+		INSERT INTO webhook_thread (
+			webhook_serial_id,
+			thread_id
+		) VALUES (
+			$1,
+			$2
+		) ON CONFLICT (webhook_serial_id, thread_id) DO NOTHING
+	`
+	_, err := r.db.ExecContext(
+		ctx,
+		query,
+		webhookSerialID,
+		threadID,
+	)
+	return err
+}
+
+func (r *Repository) GetWebhookThreadWithWebhookSerialID(
+	ctx context.Context,
+	webhookSerialID int64,
+) ([]*WebhookThread, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			webhook_thread
+		WHERE
+			webhook_serial_id = $1
+	`
+	var webhookThread []*WebhookThread
+	err := r.db.SelectContext(ctx, &webhookThread, query, webhookSerialID)
+	return webhookThread, err
+}
+
+func (r *Repository) DeleteWebhookThreadsNotInProvidedList(
+	ctx context.Context,
+	webhookSerialID int64,
+) error {
+	query := `
+		DELETE FROM
+			webhook_thread
+		WHERE
+			webhook_serial_id = $1
+	`
+	_, err := r.db.ExecContext(ctx, query, webhookSerialID)
+	return err
+}

--- a/repository/webhook_thread_test.go
+++ b/repository/webhook_thread_test.go
@@ -1,0 +1,129 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maguro-alternative/remake_bot/bot/config"
+	"github.com/maguro-alternative/remake_bot/pkg/db"
+	"github.com/maguro-alternative/remake_bot/testutil/fixtures"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookThread(t *testing.T) {
+	ctx := context.Background()
+	lastPostedAt := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	t.Run("WebhookThread挿入", func(t *testing.T) {
+		dbV1, cleanup, err := db.NewDB(ctx, config.DatabaseName(), config.DatabaseURLWithSslmode())
+		assert.NoError(t, err)
+		defer cleanup()
+
+		tx, err := dbV1.BeginTxx(ctx, nil)
+		assert.NoError(t, err)
+
+		defer tx.RollbackCtx(ctx)
+
+		tx.ExecContext(ctx, "DELETE FROM webhook_thread")
+
+		f := &fixtures.Fixture{DBv1: tx}
+		f.Build(t,
+			fixtures.NewWebhook(ctx, func(b *fixtures.Webhook) {
+				b.GuildID = "1111"
+				b.WebhookID = "22222"
+				b.SubscriptionType = "youtube"
+				b.SubscriptionID = "test"
+				b.LastPostedAt = lastPostedAt
+			}),
+		)
+
+		repo := NewRepository(tx)
+
+		err = repo.InsertWebhookThread(ctx, *f.Webhooks[0].WebhookSerialID, "test")
+		assert.NoError(t, err)
+
+		var webhookThreads []*WebhookThread
+		err = tx.SelectContext(ctx, &webhookThreads, "SELECT * FROM webhook_thread")
+		assert.NoError(t, err)
+		assert.Len(t, webhookThreads, 1)
+	})
+
+	t.Run("WebhookThread挿入(既存のものはスルー)", func(t *testing.T) {
+		dbV1, cleanup, err := db.NewDB(ctx, config.DatabaseName(), config.DatabaseURLWithSslmode())
+		assert.NoError(t, err)
+		defer cleanup()
+
+		tx, err := dbV1.BeginTxx(ctx, nil)
+		assert.NoError(t, err)
+
+		defer tx.RollbackCtx(ctx)
+
+		tx.ExecContext(ctx, "DELETE FROM webhook_thread")
+
+		f := &fixtures.Fixture{DBv1: tx}
+		f.Build(t,
+			fixtures.NewWebhook(ctx, func(b *fixtures.Webhook) {
+				b.GuildID = "1111"
+				b.WebhookID = "22222"
+				b.SubscriptionType = "youtube"
+				b.SubscriptionID = "test"
+				b.LastPostedAt = lastPostedAt
+			}).Connect(
+				fixtures.NewWebhookThread(ctx, func(b *fixtures.WebhookThread) {
+					b.WebhookSerialID = *f.Webhooks[0].WebhookSerialID
+					b.ThreadID = "test"
+				}),
+			),
+		)
+
+		repo := NewRepository(tx)
+
+		err = repo.InsertWebhookThread(ctx, *f.Webhooks[0].WebhookSerialID, "test")
+		assert.NoError(t, err)
+
+		var webhookThreads []*WebhookThread
+		err = tx.SelectContext(ctx, &webhookThreads, "SELECT * FROM webhook_thread")
+		assert.NoError(t, err)
+		assert.Len(t, webhookThreads, 1)
+	})
+
+	t.Run("WebhookThread削除", func(t *testing.T) {
+		dbV1, cleanup, err := db.NewDB(ctx, config.DatabaseName(), config.DatabaseURLWithSslmode())
+		assert.NoError(t, err)
+		defer cleanup()
+
+		tx, err := dbV1.BeginTxx(ctx, nil)
+		assert.NoError(t, err)
+
+		defer tx.RollbackCtx(ctx)
+
+		tx.ExecContext(ctx, "DELETE FROM webhook_thread")
+
+		f := &fixtures.Fixture{DBv1: tx}
+		f.Build(t,
+			fixtures.NewWebhook(ctx, func(b *fixtures.Webhook) {
+				b.GuildID = "1111"
+				b.WebhookID = "22222"
+				b.SubscriptionType = "youtube"
+				b.SubscriptionID = "test"
+				b.LastPostedAt = lastPostedAt
+			}).Connect(
+				fixtures.NewWebhookThread(ctx, func(b *fixtures.WebhookThread) {
+					b.WebhookSerialID = *f.Webhooks[0].WebhookSerialID
+					b.ThreadID = "test"
+				}),
+			),
+		)
+
+		repo := NewRepository(tx)
+
+		err = repo.DeleteWebhookThreadsNotInProvidedList(ctx, *f.Webhooks[0].WebhookSerialID)
+		assert.NoError(t, err)
+
+		var webhookThreads []*WebhookThread
+		err = tx.SelectContext(ctx, &webhookThreads, "SELECT * FROM webhook_thread")
+		assert.NoError(t, err)
+		assert.Len(t, webhookThreads, 0)
+	})
+}

--- a/tasks/internal/youtube_test.go
+++ b/tasks/internal/youtube_test.go
@@ -39,6 +39,9 @@ func TestYoutubeRssReader(t *testing.T) {
 		UpdateWebhookWithLastPostedAtFunc: func(ctx context.Context, webhookSerialID int64, lastPostedAt time.Time) error {
 			return nil
 		},
+		GetWebhookThreadWithWebhookSerialIDFunc: func(ctx context.Context, webhookSerialID int64) ([]*repository.WebhookThread, error) {
+			return []*repository.WebhookThread{}, nil
+		},
 	}
 	webhookSerialId := int64(1)
 	webhook := repository.Webhook{

--- a/testutil/fixtures/fixtures.go
+++ b/testutil/fixtures/fixtures.go
@@ -25,6 +25,7 @@ type Fixture struct {
 	WebhookUserMentions       []*WebhookUserMention
 	WebhookRoleMentions       []*WebhookRoleMention
 	WebhookWords              []*WebhookWord
+	WebhookThreads            []*WebhookThread
 
 	DBv1 db.Driver
 }

--- a/testutil/fixtures/webhook.go
+++ b/testutil/fixtures/webhook.go
@@ -45,6 +45,9 @@ func NewWebhook(ctx context.Context, setter ...func(b *Webhook)) *ModelConnector
 			case *WebhookRoleMention:
 				webhookRoleMention := connectingModel
 				webhookRoleMention.WebhookSerialID = *webhook.WebhookSerialID
+			case *WebhookThread:
+				webhookThread := connectingModel
+				webhookThread.WebhookSerialID = *webhook.WebhookSerialID
 			default:
 				t.Fatalf("%T cannot be connected to %T", connectingModel, webhook)
 			}

--- a/testutil/fixtures/webhook_thread.go
+++ b/testutil/fixtures/webhook_thread.go
@@ -1,0 +1,50 @@
+package fixtures
+
+import (
+	"context"
+	"testing"
+)
+
+type WebhookThread struct {
+	WebhookSerialID int64  `db:"webhook_serial_id"`
+	ThreadID        string `db:"thread_id"`
+}
+
+func NewWebhookThread(ctx context.Context, setter ...func(b *WebhookThread)) *ModelConnector {
+	webhookThread := &WebhookThread{
+		WebhookSerialID: 1,
+		ThreadID:        "thread_id",
+	}
+
+	return &ModelConnector{
+		Model: webhookThread,
+		setter: func() {
+			for _, s := range setter {
+				s(webhookThread)
+			}
+		},
+		addToFixture: func(t *testing.T, f *Fixture) {
+			f.WebhookThreads = append(f.WebhookThreads, webhookThread)
+		},
+		connect: func(t *testing.T, f *Fixture, connectingModel interface{}) {
+			switch connectingModel.(type) {
+			default:
+				t.Fatalf("%T cannot be connected to %T", connectingModel, webhookThread)
+			}
+		},
+		insertTable: func(t *testing.T, f *Fixture) {
+			_, err := f.DBv1.NamedExecContext(ctx, `
+				INSERT INTO webhook_thread (
+					webhook_serial_id,
+					thread_id
+				) VALUES (
+					:webhook_serial_id,
+					:thread_id
+				)
+			`, webhookThread)
+			if err != nil {
+				t.Fatalf("insert error: %v", err)
+			}
+		},
+	}
+}

--- a/testutil/mock/session.go
+++ b/testutil/mock/session.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"io"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -24,6 +25,8 @@ type SessionMock struct {
 	InteractionRespondFunc         func(interaction *discordgo.Interaction, resp *discordgo.InteractionResponse, options ...discordgo.RequestOption) error
 	UserChannelPermissionsFunc     func(userID string, channelID string, fetchOptions ...discordgo.RequestOption) (apermissions int64, err error)
 	UserGuildsFunc                 func(limit int, beforeID string, afterID string, options ...discordgo.RequestOption) (st []*discordgo.UserGuild, err error)
+	ThreadsArchivedFunc				func(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error)
+	ThreadsPrivateArchivedFunc func(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error)
 	WebhookFunc                    func(webhookID string, options ...discordgo.RequestOption) (st *discordgo.Webhook, err error)
 	WebhookExecuteFunc             func(webhookID string, token string, wait bool, data *discordgo.WebhookParams, options ...discordgo.RequestOption) (st *discordgo.Message, err error)
 	WebhookThreadExecuteFunc       func(webhookID, token string, wait bool, threadID string, data *discordgo.WebhookParams, options ...discordgo.RequestOption) (st *discordgo.Message, err error)
@@ -89,6 +92,14 @@ func (s *SessionMock) InteractionRespond(interaction *discordgo.Interaction, res
 	return nil
 }
 
+func (s *SessionMock) ThreadsArchived(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error) {
+	return s.ThreadsArchivedFunc(channelID, before, limit, options...)
+}
+
+func (s *SessionMock) ThreadsPrivateArchived(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error) {
+	return s.ThreadsPrivateArchivedFunc(channelID, before, limit, options...)
+}
+
 func (s *SessionMock) UserChannelPermissions(userID string, channelID string, fetchOptions ...discordgo.RequestOption) (apermissions int64, err error) {
 	return s.UserChannelPermissionsFunc(userID, channelID, fetchOptions...)
 }
@@ -128,6 +139,8 @@ type Session interface {
 	InteractionRespond(interaction *discordgo.Interaction, resp *discordgo.InteractionResponse, options ...discordgo.RequestOption) error
 	UserChannelPermissions(userID string, channelID string, fetchOptions ...discordgo.RequestOption) (apermissions int64, err error)
 	UserGuilds(limit int, beforeID string, afterID string, withCounts bool, options ...discordgo.RequestOption) (st []*discordgo.UserGuild, err error)
+	ThreadsArchived(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error)
+	ThreadsPrivateArchived(channelID string, before *time.Time, limit int, options ...discordgo.RequestOption) (threads *discordgo.ThreadsList, err error)
 	Webhook(webhookID string, options ...discordgo.RequestOption) (st *discordgo.Webhook, err error)
 	WebhookExecute(webhookID string, token string, wait bool, data *discordgo.WebhookParams, options ...discordgo.RequestOption) (st *discordgo.Message, err error)
 	WebhookThreadExecute(webhookID, token string, wait bool, threadID string, data *discordgo.WebhookParams, options ...discordgo.RequestOption) (st *discordgo.Message, err error)

--- a/web/handler/views/guildid/webhook/webhook.go
+++ b/web/handler/views/guildid/webhook/webhook.go
@@ -96,7 +96,7 @@ func (h *WebhookViewHandler) Index(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, webhook := range webhooks {
-		webhookForm := internal.CreateWebhookSelectForm(guildWebhooks, webhook.WebhookID)
+		webhookForm := internal.CreateWebhookSelectForm(h.indexService.DiscordSession, h.indexService.DiscordBotState, guildWebhooks, webhook.WebhookID)
 
 		subscriptionSelectForm := internal.CreateSubscriptionsSelectForm(subscriptionNames, webhook.SubscriptionType)
 
@@ -185,6 +185,8 @@ func (h *WebhookViewHandler) Index(w http.ResponseWriter, r *http.Request) {
 	}
 
 	webhookFormBuilder.WriteString(internal.CreateNewWebhookForm(
+		h.indexService.DiscordSession,
+		h.indexService.DiscordBotState,
 		guildWebhooks,
 		guild,
 		subscriptionNames,


### PR DESCRIPTION
# なぜやるか
- Webhookはスレッドでも運用が可能とわかったため。
# やったこと
- Webhookの投稿にスレッドを対応。
# 積み残し
- 特になし。
# 確認事項
- [x] 想定通りに動作するか確認したか
- [x] テストコードはすべて通るか
