### PR TITLE
aesのpanic抑制

### DIFF
--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -78,6 +78,11 @@ func (a AES) Decrypt(data []byte, iv []byte) ([]byte, error) {
 		return nil, err
 	}
 	decrypted := make([]byte, len(data))
+	// ブロックサイズとivの長さが一致しない場合、panicを起こす
+	if len(iv) != block.BlockSize() {
+		fmt.Println(len(iv), block.BlockSize())
+		return nil, fmt.Errorf("iv length must be equal to block size")
+	}
 	// 復号化
 	cbcDecrypter := cipher.NewCBCDecrypter(block, iv)
 	cbcDecrypter.CryptBlocks(decrypted, data)


### PR DESCRIPTION
# なぜやるか
- 復号化の際にまだpanicを起こす部分があったため。
# やったこと
- 該当部分にpanicを起こす状況の際にエラーを返すように変更
# 積み残し

# 確認事項
- [ ] 想定通りに動作するか確認したか
- [ ] テストコードはすべて通るか
